### PR TITLE
Modified the loop so that it exits if an error is reported

### DIFF
--- a/src/NYoutubeDL/YoutubeDL.cs
+++ b/src/NYoutubeDL/YoutubeDL.cs
@@ -236,7 +236,7 @@ namespace NYoutubeDL
         public DownloadInfo GetDownloadInfo(string url)
         {
             this.VideoUrl = url;
-            return this.GetDownloadInfo() ?? new DownloadInfo();
+            return this.GetDownloadInfo();
         }
 
         /// <summary>

--- a/src/NYoutubeDL/YoutubeDL.cs
+++ b/src/NYoutubeDL/YoutubeDL.cs
@@ -199,16 +199,23 @@ namespace NYoutubeDL
             }
 
             List<DownloadInfo> infos = new List<DownloadInfo>();
+            bool encounteredError = false;
 
             YoutubeDL infoYdl = new YoutubeDL(this.YoutubeDlPath) {VideoUrl = this.VideoUrl, isInfoProcess = true};
             infoYdl.Options.VerbositySimulationOptions.DumpSingleJson = true;
             infoYdl.Options.VerbositySimulationOptions.Simulate = true;
             infoYdl.Options.GeneralOptions.FlatPlaylist = true;
             infoYdl.StandardOutputEvent += (sender, output) => { infos.Add(DownloadInfo.CreateDownloadInfo(output)); };
+            infoYdl.StandardErrorEvent += (sender, errorOutput) => { encounteredError = true; };
             infoYdl.Download(true).WaitForExit();
 
             while (infoYdl.ProcessRunning || infos.Count == 0)
             {
+                if (encounteredError)
+                {
+                    return null;
+                }
+
                 Thread.Sleep(1);
             }
 
@@ -229,7 +236,7 @@ namespace NYoutubeDL
         public DownloadInfo GetDownloadInfo(string url)
         {
             this.VideoUrl = url;
-            return this.GetDownloadInfo();
+            return this.GetDownloadInfo() ?? new DownloadInfo();
         }
 
         /// <summary>
@@ -305,7 +312,7 @@ namespace NYoutubeDL
 
             if (!this.isInfoProcess)
             {
-                this.Info = this.GetDownloadInfo();
+                this.Info = this.GetDownloadInfo() ?? new DownloadInfo();
             }
 
             this.RunCommand = this.processStartInfo.FileName + " " + this.processStartInfo.Arguments;


### PR DESCRIPTION
I've added an event listener for standard error events so the loop can be interrupted if an error is emitted and no video info is emitted by youtube-dl which is the case if the video does not exist.